### PR TITLE
fix: skip one unresolvable CPE match instead of dropping a day

### DIFF
--- a/cve2stix/cpe_match.py
+++ b/cve2stix/cpe_match.py
@@ -38,7 +38,21 @@ def parse_cpe_matches(
     deprecations = []
 
     for match_data in get_matches_for_cve(cve_id=indicator.name):
-        objects = parse_objects_for_criteria(match_data)
+        try:
+            objects = parse_objects_for_criteria(match_data)
+        except ValueError as exc:
+            # NVD's CVE match feed can reference a SWID that its CPE dictionary and
+            # CPE API do not contain. That is one broken match criterion, not a reason
+            # to discard the CVE or every other CVE modified that day. Before this
+            # boundary, one such SWID failed the whole Celery chord: the 2026-08-19
+            # daily run dropped 1,343 NVD updates and never published meta.json.
+            logging.error(
+                "skipping unresolvable CPE match %s for %s: %s",
+                match_data.get("matchCriteriaId", "<unknown>"),
+                indicator.name,
+                exc,
+            )
+            continue
         softwares.update({obj["id"]: obj for obj in objects[1:]})
         groupings.append(objects[0])
         relationships.extend(relate_indicator(objects[0], indicator))

--- a/tests/src/test_cpe_match.py
+++ b/tests/src/test_cpe_match.py
@@ -54,6 +54,34 @@ def test_parse_cpe_matches(indicator_with_cpes):
         "relationship--3ad3537e-cc20-571d-9248-b63c23fc0b2b",
     }
 
+
+def test_parse_cpe_matches_skips_one_unresolvable_match(indicator_with_cpes, caplog):
+    broken = {"matchCriteriaId": "BROKEN-SWID"}
+    good = {"matchCriteriaId": "GOOD-SWID"}
+    grouping = {"id": "grouping--good", "name": "good"}
+    software = {"id": "software--good"}
+
+    with (
+        patch.object(cpe_match, "get_matches_for_cve", return_value=[broken, good]),
+        patch.object(
+            cpe_match,
+            "parse_objects_for_criteria",
+            side_effect=[ValueError("SWID missing from NVD"), [grouping, software]],
+        ),
+        patch.object(cpe_match, "relate_indicator", return_value=["relationship"]),
+        patch.object(cpe_match, "parse_deprecations", return_value=["deprecation"]),
+    ):
+        groupings, softwares, relationships, deprecations = (
+            cpe_match.parse_cpe_matches(indicator_with_cpes)
+        )
+
+    assert groupings == [grouping]
+    assert softwares == [software]
+    assert relationships == ["relationship"]
+    assert deprecations == ["deprecation"]
+    assert "skipping unresolvable CPE match BROKEN-SWID" in caplog.text
+    assert indicator_with_cpes.name in caplog.text
+
 @pytest.fixture
 def indicator_with_cpes():
     return Indicator(


### PR DESCRIPTION
Summary
This replaces the closed PR #139 with the same change set.

What changed
- catch ValueError from parse_objects_for_criteria for one broken CPE match
- log the skipped matchCriteriaId and CVE id
- continue processing the remaining matches for that CVE
- add a test covering one broken match followed by one valid match

Why
A single unresolvable CPE or SWID-backed match criterion from NVD should not fail the full CVE conversion or the wider daily batch.